### PR TITLE
Blackfynn path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ jobs:
       script: 
        - flake8 pathman/
        - mypy pathman/
-       - pytest
+       - pytest --integration
 
     - stage: release
       if: tag IS present

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,13 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption("--integration", action="store_true",
+                     help="run integration tests")
+
+
+def pytest_runtest_setup(item):
+    if 'integration' in item.keywords and
+    not item.config.getoption("--integration"):
+
+        pytest.skip("Needs --integration option to run")

--- a/conftest.py
+++ b/conftest.py
@@ -7,7 +7,6 @@ def pytest_addoption(parser):
 
 
 def pytest_runtest_setup(item):
-    if 'integration' in item.keywords and
-    not item.config.getoption("--integration"):
+    if 'integration' in item.keywords and not item.config.getoption("--integration"):
 
         pytest.skip("Needs --integration option to run")

--- a/pathman/path.py
+++ b/pathman/path.py
@@ -799,6 +799,7 @@ def determine_output_location(abspath: str) -> str:
     -----
     Possible output locations include:
         - s3
+        - blackfynn
         - local
     """
     if abspath.startswith("s3"):

--- a/pathman/path.py
+++ b/pathman/path.py
@@ -375,7 +375,7 @@ class BlackfynnPath(AbstractPath, RemotePath):
                 else:
                     extension = None
                     if hasattr(item, 'sources'):
-                        if len(item.sources) > 0:
+                        if len(item.sources) > 1:
                             raise RuntimeError(
                                 "{} has too many sources").format(item)
                         extension = Path(item.sources[0].s3_key).extension
@@ -408,7 +408,7 @@ class BlackfynnPath(AbstractPath, RemotePath):
             ext = None
             if hasattr(item, 'sources'):
                 ext = Path(item.sources[0].s3_key).extension
-                if len(item.sources) > 0:
+                if len(item.sources) > 1:
                     raise RuntimeError("{} has too many sources").format(item)
             files.append(self.join(item.name + (ext if ext else '')))
         return files
@@ -440,6 +440,8 @@ class BlackfynnPath(AbstractPath, RemotePath):
     def _read(self):
         if not self.is_file():
             return
+        if len(self._object.sources) > 1:
+            raise RuntimeError("{} has too many sources").format(self._object)
         url = self._object.sources[0].url
         response = urllib.request.urlopen(url)
         return response.read()

--- a/pathman/path.py
+++ b/pathman/path.py
@@ -228,12 +228,14 @@ class BlackfynnPath(AbstractPath, RemotePath):
             path = path[:path.rfind('.')]
         else:
             self._extension = ''
-        if dataset is not None:
+        if dataset is None:
+            self._pathstr = path
+            if len(parts) == 0:
+                raise ValueError("Must specify a dataset")
+            dataset = self.dataset
+        else:
             self._pathstr = 'bf://' + \
                 os.path.join(dataset, path[len('bf://'):])
-        else:
-            self._pathstr = path
-            dataset = self.dataset
         self._profile = profile
         bf = Blackfynn(self._profile)
         root = None

--- a/pathman/path.py
+++ b/pathman/path.py
@@ -395,7 +395,7 @@ class BlackfynnPath(AbstractPath, RemotePath):
         regex = re.compile(regex_text)
         files = self.walk()
         seen = set()
-        return [file for file in files
+        return [_file for _file in files
                 for match in [regex.match(file.path)] if match
                 for path in [match.group(0)]
                 if not (path in seen or seen.add(path))]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 s3fs
 boto3
 requests
+blackfynn

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 s3fs
 boto3
+requests

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,6 +3,9 @@ exclude = .git, setup.py docs/* build/* pathman/__init__.py
 
 [tool:pytest]
 addopts = --strict --cov=pathman --cov-report=term --cov-report=html
+markers =
+    remote
+    integration
 
 [coverage:run]
 source = pathman

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -278,38 +278,39 @@ class TestBlackfynnPath(object):
         assert path._extension == ".txt"
 
     @pytest.mark.parametrize("path,expectation", [
-        ('test-pathman/', True),
-        ('test-pathman/folder/', True),
-        ('test-pathman/folder/subfolder/', False),
-        ('test-pathman/file.txt', True),
-        ('test-pathman/table.csv', True)
+        ('bf://test-pathman/', True),
+        ('bf://test-pathman/folder/', True),
+        ('bf://test-pathman/folder/subfolder/', False),
+        ('bf://test-pathman/file.txt', True),
+        ('bf://test-pathman/table.csv', True)
     ])
     def test_exists(self, path, expectation):
         assert BlackfynnPath(path).exists() == expectation
 
     @pytest.mark.parametrize("path,expectation", [
-        ('test-pathman/', True),
-        ('test-pathman/folder/', True),
-        ('test-pathman/folder/subfolder/', False),
-        ('test-pathman/file.txt', False),
-        ('test-pathman/table.csv', False)
+        ('bf://test-pathman/', True),
+        ('bf://test-pathman/folder/', True),
+        ('bf://test-pathman/folder/subfolder/', False),
+        ('bf://test-pathman/file.txt', False),
+        ('bf://test-pathman/table.csv', False)
     ])
     def test_is_dir(self, path, expectation):
         assert BlackfynnPath(path).is_dir() == expectation
 
     @pytest.mark.parametrize("path,expectation", [
-        ('test-pathman/', False),
-        ('test-pathman/folder/', False),
-        ('test-pathman/folder/subfolder/', False),
-        ('test-pathman/file.txt', True),
-        ('test-pathman/table.csv', True)
+        ('bf://test-pathman/', False),
+        ('bf://test-pathman/folder/', False),
+        ('bf://test-pathman/folder/subfolder/', False),
+        ('bf://test-pathman/file.txt', True),
+        ('bf://test-pathman/table.csv', True)
     ])
     def test_is_file(self, path, expectation):
         assert BlackfynnPath(path).is_file() == expectation
 
     def test_ls(self):
-        expectations = ['bf://test-pathman/folder', 
-            'bf://test-pathman/file.txt', 'bf://test-pathman/table.csv']
+        expectations = ['bf://test-pathman/folder',
+                        'bf://test-pathman/file.txt',
+                        'bf://test-pathman/table.csv']
         path = BlackfynnPath("bf://", self.ds.name)
         files = [str(file) + file.extension for file in path.ls()]
         for file in files:
@@ -332,26 +333,26 @@ class TestBlackfynnPath(object):
 
     def test_mkdir(self):
         path = BlackfynnPath("bf://folder/test_mkdir", self.ds.name)
-        assert path.exists() == False
+        assert path.exists() is False
         path.mkdir()
-        assert path.is_dir() == True and path.exists() == True
-        path._object.delete()
-    
+        assert path.is_dir() is True and path.exists() is True
+        path._bf_object.delete()
+
     def test_rmdir(self):
         self.ds.create_collection("test_remove")
         path = BlackfynnPath("bf://test_remove", self.ds.name)
-        assert path.exists() == True and path.is_dir() == True
+        assert path.exists() is True and path.is_dir() is True
         path.rmdir()
-        assert path.exists() == False
+        assert path.exists() is False
 
     def test_write(self):
         path = BlackfynnPath("bf://write.txt", self.ds.name)
         to_write = "Hello, World!"
         path.write_text(to_write)
-        bf = Blackfynn()
-        retrieved = urllib.request.urlopen(path._object.sources[0].url).read()
+        retrieved = urllib.request.urlopen(
+            path._bf_object.sources[0].url).read()
         assert str(retrieved, 'utf-8') == "Hello, World!"
-        path._object.delete()
+        path._bf_object.delete()
 
     def test_read(self):
         path = BlackfynnPath("bf://file.txt", self.ds.name)
@@ -359,18 +360,17 @@ class TestBlackfynnPath(object):
 
     def test_touch(self):
         path = BlackfynnPath("bf://touch.txt", self.ds.name)
-        assert path.exists() == False
+        assert path.exists() is False
         path.touch()
-        assert path.exists() == True and path.is_file() == True
+        assert path.exists() is True and path.is_file() is True
 
     def test_remove(self):
         path = BlackfynnPath("bf://remove.txt", self.ds.name)
-        assert path.exists() == False
+        assert path.exists() is False
         path.touch()
-        assert path.exists() == True
+        assert path.exists() is True
         path.remove()
-        assert path.exists() == False
-
+        assert path.exists() is False
 
 
 class TestS3Path(object):

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -1,5 +1,6 @@
 import os
 import pytest
+import mock
 import boto3
 import functools
 from moto import mock_s3
@@ -17,6 +18,21 @@ data = functools.partial(resource_filename, 'tests.resources')
 
 real_bucket = "s3://test-bucket"
 real_file = "s3://test-bucket/test-key/test_file.txt"
+
+
+@mock.patch('pathman.path.Blackfynn')
+def mock_blackfynn(self, mock_bf):
+
+    bf = None
+
+    token = os.environ.get('BLACKFYNN_API_TOKEN', None)
+    secret = os.environ.get('BLACKFYNN_API_SECRET', None)
+    if token and secret:
+        bf = Blackfynn(api_token=token, api_secret=secret)
+    else:
+        bf = Blackfynn()
+
+    mock_bf.return_value = bf
 
 
 def local_file():
@@ -247,7 +263,7 @@ class TestLocalPath(object):
         assert str(path.join(*segments)) == os.path.join("", *segments)
 
 
-# @pytest.mark.integration
+@pytest.mark.integration
 class TestBlackfynnPath(object):
 
     @classmethod

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -266,6 +266,11 @@ class TestBlackfynnPath(object):
     @classmethod
     def setup_class(cls):
         bf = Blackfynn()
+        try:
+            old_ds = bf.get_dataset('test-pathman')
+            bf._api.datasets.delete(old_ds)
+        except Exception:
+            pass
         cls.ds = bf.create_dataset('test-pathman')
         cls.ds.create_collection("folder")
         with TemporaryDirectory() as tmp:

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -20,19 +20,15 @@ real_bucket = "s3://test-bucket"
 real_file = "s3://test-bucket/test-key/test_file.txt"
 
 
-@mock.patch('pathman.path.Blackfynn')
-def mock_blackfynn(self, mock_bf):
+class MockBlackfynn(Blackfynn):
 
-    bf = None
-
-    token = os.environ.get('BLACKFYNN_API_TOKEN', None)
-    secret = os.environ.get('BLACKFYNN_API_SECRET', None)
-    if token and secret:
-        bf = Blackfynn(api_token=token, api_secret=secret)
-    else:
-        bf = Blackfynn()
-
-    mock_bf.return_value = bf
+    def __init__(self, profile=None, *args, **kwargs):
+        token = os.environ.get('BLACKFYNN_API_TOKEN', None)
+        secret = os.environ.get('BLACKFYNN_API_SECRET', None)
+        if token and secret:
+            super().__init__(api_token=token, api_secret=secret)
+        else:
+            super().__init__(profile)
 
 
 def local_file():
@@ -264,6 +260,7 @@ class TestLocalPath(object):
 
 
 @pytest.mark.integration
+@mock.patch('pathman.path.Blackfynn', new=MockBlackfynn)
 class TestBlackfynnPath(object):
 
     @classmethod

--- a/tests/test_path.py
+++ b/tests/test_path.py
@@ -315,6 +315,21 @@ class TestBlackfynnPath(object):
         for file in files:
             assert str(file) in expectations
 
+    def test_walk(self):
+        path = BlackfynnPath("bf://", self.ds.name)
+        files = path.walk()
+        assert len(files) == 2
+
+    @pytest.mark.parametrize("pattern, expected_length", [
+        ("*.txt", 1),
+        ("*.*", 2),
+        ("*/*.*", 0)
+    ])
+    def test_glob(self, pattern, expected_length):
+        path = BlackfynnPath("bf://", self.ds.name)
+        files = path.glob(pattern)
+        assert len(files) == expected_length
+
     def test_mkdir(self):
         path = BlackfynnPath("bf://folder/test_mkdir", self.ds.name)
         assert path.exists() == False


### PR DESCRIPTION
Added a `BlackfynnPath` class for interacting with the Blackfynn platform as a file system. 

Notes:
 - Attempting to load files with multiple sources from `ls`, `walk`, or `glob` will result in an error because it's impossible to infer the extension. Attempting to read from a file with multiple sources will cause an error for similar reasons.
 - `BlackfynnPath` infers whether or not the thing it refers to is a folder of file by the presence of an extension (ie. a `.` in the name), however it's possible to name folders like `folder.txt`, which can cause unexpected behavior.