### PR TITLE
Bump version to v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [0.1.2]
+## [0.1.3]
 ### Added
 - Path.walk() now takes `**kwargs` to pass into the underlying implementation
 

--- a/pathman/__init__.py
+++ b/pathman/__init__.py
@@ -1,3 +1,3 @@
 from pathman.path import Path, copy
 
-__version__ = "0.1.2"
+__version__ = "0.1.3"


### PR DESCRIPTION
The 0.1.2 tag (and version on pypa) is already taken by a prerelease, we can't overwrite it