### PR TITLE
Hotfix pass orig kwargs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.2]
+### Fixed
+- Pass original kwargs with any methods that return `Path`
+
 ## [0.2.1]
 ### Changed
 - Removed optional requirements from requirements.txt

--- a/pathman/__init__.py
+++ b/pathman/__init__.py
@@ -1,3 +1,3 @@
 from .path import Path
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/pathman/_impl/s3.py
+++ b/pathman/_impl/s3.py
@@ -18,7 +18,7 @@ class S3Path(AbstractPath, RemotePath):
 
         from s3fs import S3FileSystem  # type: ignore
 
-        self._original_kwargs = kwargs
+        self._original_kwargs = dict({}, **kwargs)
         self._pathstr = path
         self._path = S3FileSystem(anon=False, **kwargs)
 

--- a/pathman/path.py
+++ b/pathman/path.py
@@ -22,6 +22,7 @@ class Path(AbstractPath, os.PathLike):
            A path string
         """
         path = str(path)
+        self._original_kwargs = kwargs
         self._pathstr: str = path
         self._isfile: bool = is_file(path)
         self._location: str = determine_output_location(path)
@@ -46,7 +47,7 @@ class Path(AbstractPath, os.PathLike):
         return self._pathstr == other._pathstr
 
     def __truediv__(self, key) -> "Path":
-        return Path(self._impl.__truediv__(key)._pathstr)
+        return Path(self._impl.__truediv__(key)._pathstr, **self._original_kwargs)
 
     @property
     def extension(self) -> str:
@@ -90,7 +91,7 @@ class Path(AbstractPath, os.PathLike):
 
     def join(self, *pathsegments) -> "Path":
         """ Combine the current path with the given segments """
-        return Path(self._impl.join(*pathsegments)._pathstr)
+        return Path(self._impl.join(*pathsegments)._pathstr, **self._original_kwargs)
 
     def basename(self) -> str:
         """Return the base name of the current path
@@ -167,17 +168,17 @@ class Path(AbstractPath, os.PathLike):
 
     def expanduser(self) -> "Path":
         """ Return a new path with ~ expanded """
-        return Path(self._impl.expanduser()._pathstr)
+        return Path(self._impl.expanduser()._pathstr, **self._original_kwargs)
 
     def dirname(self) -> "Path":
         """Return the directory name of the current path. Mimics the behavior
         of `os.path.dirname`
         """
-        return Path(os.path.dirname(self._pathstr))
+        return Path(os.path.dirname(self._pathstr), **self._original_kwargs)
 
     def abspath(self) -> "Path":
         """ Make the current path absolute """
-        return Path(self._impl.abspath()._pathstr)
+        return Path(self._impl.abspath()._pathstr, **self._original_kwargs)
 
     def walk(self, **kwargs) -> Generator["Path", None, None]:
         """Get a list of files below the current path
@@ -187,16 +188,20 @@ class Path(AbstractPath, os.PathLike):
         This does not mirror the behavior of `os.walk`. A list of absolute
         paths are returned
         """
-        return (Path(p._pathstr) for p in self._impl.walk(**kwargs))
+        return (
+            Path(p._pathstr, **self._original_kwargs) for p in self._impl.walk(**kwargs)
+        )
 
     def ls(self) -> List["Path"]:
-        return [Path(p._pathstr) for p in self._impl.ls()]
+        return [Path(p._pathstr, **self._original_kwargs) for p in self._impl.ls()]
 
     def glob(self, path) -> List["Path"]:
-        return [Path(p._pathstr) for p in self._impl.glob(path)]
+        return [
+            Path(p._pathstr, **self._original_kwargs) for p in self._impl.glob(path)
+        ]
 
     def with_suffix(self, suffix) -> "Path":
-        return Path(self._impl.with_suffix(suffix)._pathstr)
+        return Path(self._impl.with_suffix(suffix)._pathstr, **self._original_kwargs)
 
     @property
     def stem(self) -> str:

--- a/pathman/path.py
+++ b/pathman/path.py
@@ -22,7 +22,7 @@ class Path(AbstractPath, os.PathLike):
            A path string
         """
         path = str(path)
-        self._original_kwargs = kwargs
+        self._original_kwargs = dict({}, **kwargs)
         self._pathstr: str = path
         self._isfile: bool = is_file(path)
         self._location: str = determine_output_location(path)

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 
 with open("requirements.txt", "r") as fd:
     requirements = fd.readlines()


### PR DESCRIPTION
Certain methods on the `Path` object return a new path or paths. These paths should be constructed with the same kwargs that were used to construct the initial path. This is mostly relevant for `S3Path`. For example, if additional configuration is passed (i.e. pointing to a different `endpoint-url` or using SSE encryption), we want any paths derived from it to inherit that configuration.

```python
path = Path("s3://test-bucket", client_kwargs={"endpoint_url":"http://some-other-url"})
path.exists() # returns True

sub_dir = path / "my_file.csv"
sub_dir.exists(). # returns False because the path returned by the above does not pass along `client_kwargs`

```