### PR TITLE
Make it possible to pass in the `anon` flag so that `S3FileSystem` can be initialized with it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [0.2.3]
+### Added
+- Made it possible to pass in `anon=True` to support uses without auth (default is still `False`).
+
 ## [0.2.2]
 ### Fixed
 - Pass original kwargs with any methods that return `Path`

--- a/pathman/_impl/s3.py
+++ b/pathman/_impl/s3.py
@@ -20,7 +20,10 @@ class S3Path(AbstractPath, RemotePath):
 
         self._original_kwargs = dict({}, **kwargs)
         self._pathstr = path
-        self._path = S3FileSystem(anon=False, **kwargs)
+        if "anon" not in kwargs:
+            kwargs["anon"] = False
+        self._anon = kwargs["anon"]
+        self._path = S3FileSystem(**kwargs)
 
     def __str__(self) -> str:
         return self._pathstr

--- a/pathman/_impl/s3.py
+++ b/pathman/_impl/s3.py
@@ -76,7 +76,7 @@ class S3Path(AbstractPath, RemotePath):
         return S3Path(joined, **self._original_kwargs)
 
     def open(self, mode="rb", **kwargs):
-        return self._path._open(self._pathstr, mode=mode, **kwargs)
+        return self._path.open(self._pathstr, mode=mode, **kwargs)
 
     def write_bytes(self, contents, **kwargs):
         with self.open("wb") as f:

--- a/pathman/_impl/s3.py
+++ b/pathman/_impl/s3.py
@@ -1,4 +1,5 @@
 import os
+import io
 import importlib
 from typing import List, Generator
 from pathlib import PurePath
@@ -74,8 +75,8 @@ class S3Path(AbstractPath, RemotePath):
         joined = os.path.join(self._pathstr, *pathsegments)
         return S3Path(joined, **self._original_kwargs)
 
-    def open(self, mode="r", **kwargs):
-        return self._path.open(self._pathstr, mode=mode, **kwargs)
+    def open(self, mode="rb", **kwargs):
+        return self._path._open(self._pathstr, mode=mode, **kwargs)
 
     def write_bytes(self, contents, **kwargs):
         with self.open("wb") as f:
@@ -91,8 +92,9 @@ class S3Path(AbstractPath, RemotePath):
         return self._path.rm(self._pathstr)
 
     def read_text(self, **kwargs):
-        with self.open("r") as f:
-            contents = f.read(**kwargs)
+        with self.open("rb") as f:
+            text_wrapper = io.TextIOWrapper(f)
+            contents = text_wrapper.read()
         return contents
 
     def read_bytes(self, **kwargs):

--- a/pathman/_impl/s3.py
+++ b/pathman/_impl/s3.py
@@ -1,5 +1,4 @@
 import os
-import io
 import importlib
 from typing import List, Generator
 from pathlib import PurePath
@@ -75,7 +74,7 @@ class S3Path(AbstractPath, RemotePath):
         joined = os.path.join(self._pathstr, *pathsegments)
         return S3Path(joined, **self._original_kwargs)
 
-    def open(self, mode="rb", **kwargs):
+    def open(self, mode="r", **kwargs):
         return self._path.open(self._pathstr, mode=mode, **kwargs)
 
     def write_bytes(self, contents, **kwargs):
@@ -92,9 +91,8 @@ class S3Path(AbstractPath, RemotePath):
         return self._path.rm(self._pathstr)
 
     def read_text(self, **kwargs):
-        with self.open("rb") as f:
-            text_wrapper = io.TextIOWrapper(f)
-            contents = text_wrapper.read()
+        with self.open("r") as f:
+            contents = f.read(**kwargs)
         return contents
 
     def read_bytes(self, **kwargs):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,8 @@ mypy
 flake8
 pre-commit
 black
-s3fs
+s3fs<0.5.0
+fsspec==0.8.0
 boto3
 Sphinx>3.0
 sphinx-rtd-theme

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 from setuptools import setup, find_packages
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 
 with open("requirements.txt", "r") as fd:
     requirements = fd.readlines()


### PR DESCRIPTION
When running against `localstack` it's convience to flip the `anon` flag to `True`, since we don't necessarily want to be using local aws credentials or config